### PR TITLE
Update LocalizerAccessors.cs to enable private fields

### DIFF
--- a/PoExtractor.DotNet/LocalizerAccessors.cs
+++ b/PoExtractor.DotNet/LocalizerAccessors.cs
@@ -4,10 +4,22 @@
     {
         public static readonly string DefaultLocalizerIdentifier = "T";
 
+        public static readonly string DefaultLocalizerPrivateIdentifier = "_t";
+
         public static readonly string StringLocalizerIdentifier = "S";
+
+        public static readonly string StringLocalizerPrivateIdentifier = "_s";
 
         public static readonly string HtmlLocalizerIdentifier = "H";
 
-        public static string[] LocalizerIdentifiers = new string[] { DefaultLocalizerIdentifier, StringLocalizerIdentifier, HtmlLocalizerIdentifier };
+        public static readonly string HtmlLocalizerPrivateIdentifier = "_h";
+
+        public static string[] LocalizerIdentifiers = new string[] {    DefaultLocalizerIdentifier, 
+                                                                        DefaultLocalizerPrivateIdentifier, 
+                                                                        StringLocalizerIdentifier, 
+                                                                        StringLocalizerPrivateIdentifier, 
+                                                                        HtmlLocalizerIdentifier, 
+                                                                        HtmlLocalizerPrivateIdentifier 
+                                                                    };
     }
 }


### PR DESCRIPTION
Added accessors with proper private field names.

While evaluating the use of PoExtractor for localizing [FullStackHero](https://github.com/fullstackhero/dotnet-webapi-boilerplate), we stumbled across the problem of having to name private fields according to the current naming conventions used by PoExtractor. This resulted in loads of code style warnings ([SX1309](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md)) because private fields did not begin with an underscore.

To mediate this problem, identifiers for private fields have been added to [PoExtractor.DotNet/LocalizerAccessors.cs](https://github.com/lukaskabrt/PoExtractor/compare/master...mluepkes:privateAccessors?expand=1#diff-e78b50d010e7ecc982681584e2d2d154f1202640bf93eacd1ea22cba02183fec). Note: The alternative use of upper-case letters, e.g. _T, to at least somewhat adhere to the presented naming conventions does not work, as it results in code style warning [SA1306](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md).

Fixed artifact characters from #55 