### PR TITLE
Add cli argument for localisation-identifier

### DIFF
--- a/PoExtractor.Core.Tests/DisplayAttributeStringExtractorTests.cs
+++ b/PoExtractor.Core.Tests/DisplayAttributeStringExtractorTests.cs
@@ -10,7 +10,7 @@ namespace PoExtractor.Core.Tests
         public void ExtractLocalizedNameFromDisplayAttribute()
         {
             // Arrange
-            var csProjectProcessor = new FakeCSharpProjectProcessor();
+            var csProjectProcessor = new FakeCSharpProjectProcessor("Loc");
             var localizableStringCollection = new LocalizableStringCollection();
 
             // Act
@@ -26,7 +26,7 @@ namespace PoExtractor.Core.Tests
         public void ExtractLocalizedShortNameFromDisplayAttribute()
         {
             // Arrange
-            var csProjectProcessor = new FakeCSharpProjectProcessor();
+            var csProjectProcessor = new FakeCSharpProjectProcessor("Loc");
             var localizableStringCollection = new LocalizableStringCollection();
 
             // Act
@@ -42,7 +42,7 @@ namespace PoExtractor.Core.Tests
         public void ExtractLocalizedGroupNameFromDisplayAttribute()
         {
             // Arrange
-            var csProjectProcessor = new FakeCSharpProjectProcessor();
+            var csProjectProcessor = new FakeCSharpProjectProcessor("Loc");
             var localizableStringCollection = new LocalizableStringCollection();
 
             // Act
@@ -58,7 +58,7 @@ namespace PoExtractor.Core.Tests
         public void ExtractLocalizedDescriptionFromDisplayAttribute()
         {
             // Arrange
-            var csProjectProcessor = new FakeCSharpProjectProcessor();
+            var csProjectProcessor = new FakeCSharpProjectProcessor("Loc");
             var localizableStringCollection = new LocalizableStringCollection();
 
             // Act

--- a/PoExtractor.Core.Tests/ErrorMessageAnnotationStringExtractorTests.cs
+++ b/PoExtractor.Core.Tests/ErrorMessageAnnotationStringExtractorTests.cs
@@ -10,7 +10,7 @@ namespace PoExtractor.Core.Tests
         public void ExtractLocalizedStringsFromDataAnnotations()
         {
             // Arrange
-            var csProjectProcessor = new FakeCSharpProjectProcessor();
+            var csProjectProcessor = new FakeCSharpProjectProcessor("Loc");
             var localizableStringCollection = new LocalizableStringCollection();
 
             // Act
@@ -28,7 +28,7 @@ namespace PoExtractor.Core.Tests
         public void DataAnnotationsExtractorShouldRespectErrorMessageOrder()
         {
             // Arrange
-            var csProjectProcessor = new FakeCSharpProjectProcessor();
+            var csProjectProcessor = new FakeCSharpProjectProcessor("Loc");
             var localizableStringCollection = new LocalizableStringCollection();
 
             // Act

--- a/PoExtractor.Core.Tests/Fakes/FakeCSharpProjectProcessor.cs
+++ b/PoExtractor.Core.Tests/Fakes/FakeCSharpProjectProcessor.cs
@@ -13,6 +13,13 @@ namespace PoExtractor.Core.Tests.Fakes
     {
         private static readonly string _defaultPath = "ProjectFiles";
 
+        private readonly string identifier;
+
+        public FakeCSharpProjectProcessor(string identifier)
+        {
+            this.identifier = identifier;
+        }
+
         public void Process(string path, string basePath, LocalizableStringCollection strings)
         {
             if (string.IsNullOrEmpty(path))
@@ -28,8 +35,8 @@ namespace PoExtractor.Core.Tests.Fakes
             var codeMetadataProvider = new CodeMetadataProvider(basePath);
             var csharpWalker = new ExtractingCodeWalker(
                 new IStringExtractor<SyntaxNode>[] {
-                        new SingularStringExtractor(codeMetadataProvider),
-                        new PluralStringExtractor(codeMetadataProvider),
+                        new SingularStringExtractor(codeMetadataProvider, identifier),
+                        new PluralStringExtractor(codeMetadataProvider, identifier),
                         new ErrorMessageAnnotationStringExtractor(codeMetadataProvider),
                         new DisplayAttributeDescriptionStringExtractor(codeMetadataProvider),
                         new DisplayAttributeNameStringExtractor(codeMetadataProvider),

--- a/PoExtractor.DotNet.CS/CSharpProjectProcessor.cs
+++ b/PoExtractor.DotNet.CS/CSharpProjectProcessor.cs
@@ -12,13 +12,21 @@ namespace PoExtractor.DotNet.CS {
     /// <summary>
     /// Extracts localizable strings from all *.cs files in the project path
     /// </summary>
-    public class CSharpProjectProcessor : RazorViewsProcessor {
+    public class CSharpProjectProcessor : RazorViewsProcessor 
+    {
+        private readonly string identifier;
+
+        public CSharpProjectProcessor(string identifier)
+        {
+            this.identifier = identifier;
+        }
+
         public override void Process(string path, string basePath, LocalizableStringCollection strings) {
             var codeMetadataProvider = new CodeMetadataProvider(basePath);
             var csharpWalker = new ExtractingCodeWalker(
                 new IStringExtractor<SyntaxNode>[] {
-                        new SingularStringExtractor(codeMetadataProvider),
-                        new PluralStringExtractor(codeMetadataProvider),
+                        new SingularStringExtractor(codeMetadataProvider, identifier),
+                        new PluralStringExtractor(codeMetadataProvider, identifier),
                         new ErrorMessageAnnotationStringExtractor(codeMetadataProvider),
                         new DisplayAttributeDescriptionStringExtractor(codeMetadataProvider),
                         new DisplayAttributeNameStringExtractor(codeMetadataProvider),
@@ -46,8 +54,8 @@ namespace PoExtractor.DotNet.CS {
         protected override IStringExtractor<SyntaxNode>[] GetStringExtractors(RazorMetadataProvider razorMetadataProvider)
             => new IStringExtractor<SyntaxNode>[]
             {
-                new SingularStringExtractor(razorMetadataProvider),
-                new PluralStringExtractor(razorMetadataProvider),
+                new SingularStringExtractor(razorMetadataProvider, identifier),
+                new PluralStringExtractor(razorMetadataProvider, identifier),
                 new ErrorMessageAnnotationStringExtractor(razorMetadataProvider),
                 new DisplayAttributeDescriptionStringExtractor(razorMetadataProvider),
                 new DisplayAttributeNameStringExtractor(razorMetadataProvider),

--- a/PoExtractor.DotNet.CS/PluralStringExtractor.cs
+++ b/PoExtractor.DotNet.CS/PluralStringExtractor.cs
@@ -12,8 +12,13 @@ namespace PoExtractor.DotNet.CS {
     /// <remarks>
     /// The localizable string is identified by the name convention - T.Plural(count, "1 book", "{0} books")
     /// </remarks>
-    public class PluralStringExtractor : LocalizableStringExtractor<SyntaxNode> {
-        public PluralStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider) : base(metadataProvider) {
+    public class PluralStringExtractor : LocalizableStringExtractor<SyntaxNode>
+    {
+        private string[] localizerIdentifiers;
+
+        public PluralStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider, string identifier) : base(metadataProvider)
+        {
+            localizerIdentifiers = LocalizerAccessors.LocalizerIdentifiers.Append(identifier).ToArray();
         }
 
         public override bool TryExtract(SyntaxNode node, out LocalizableStringOccurence result) {
@@ -22,7 +27,7 @@ namespace PoExtractor.DotNet.CS {
             if (node is InvocationExpressionSyntax invocation &&
                 invocation.Expression is MemberAccessExpressionSyntax accessor &&
                 accessor.Expression is IdentifierNameSyntax identifierName &&
-                LocalizerAccessors.LocalizerIdentifiers.Contains(identifierName.Identifier.Text) &&
+                localizerIdentifiers.Contains(identifierName.Identifier.Text) &&
                 accessor.Name.Identifier.Text == "Plural") {
 
                 var arguments = invocation.ArgumentList.Arguments;

--- a/PoExtractor.DotNet.CS/SingularStringExtractor.cs
+++ b/PoExtractor.DotNet.CS/SingularStringExtractor.cs
@@ -5,36 +5,47 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using PoExtractor.Core;
 using PoExtractor.Core.Contracts;
 
-namespace PoExtractor.DotNet.CS {
+namespace PoExtractor.DotNet.CS
+{
     /// <summary>
     /// Extracts <see cref="LocalizableStringOccurence"/> with the singular text from the C# AST node
     /// </summary>
     /// <remarks>
     /// The localizable string is identified by the name convention - T["TEXT TO TRANSLATE"]
     /// </remarks>
-    public class SingularStringExtractor : LocalizableStringExtractor<SyntaxNode> {
-        public SingularStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider) : base(metadataProvider) {
+    public class SingularStringExtractor : LocalizableStringExtractor<SyntaxNode>
+    {
+        private readonly string[] localizerIdentifiers;
+
+        public SingularStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider, string identifier) : base(metadataProvider)
+        {
+            localizerIdentifiers = LocalizerAccessors.LocalizerIdentifiers.Append(identifier).ToArray();
         }
 
-        public override bool TryExtract(SyntaxNode node, out LocalizableStringOccurence result) {
+        public override bool TryExtract(SyntaxNode node, out LocalizableStringOccurence result)
+        {
             result = null;
 
-            if (node is ElementAccessExpressionSyntax accessor &&
-                accessor.Expression is IdentifierNameSyntax identifierName &&
-                LocalizerAccessors.LocalizerIdentifiers.Contains(identifierName.Identifier.Text) &&
-                accessor.ArgumentList != null) {
+            if (node is ElementAccessExpressionSyntax accessor)
 
-                var argument = accessor.ArgumentList.Arguments.FirstOrDefault();
-                if (argument != null && argument.Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression)) {
-                    result = new LocalizableStringOccurence() {
-                        Text = literal.Token.ValueText,
-                        Context = this.MetadataProvider.GetContext(node),
-                        Location = this.MetadataProvider.GetLocation(node)
-                    };
+                if (accessor.Expression is IdentifierNameSyntax identifierName)
+                    if (localizerIdentifiers.Contains(identifierName.Identifier.Text))
+                        if (accessor.ArgumentList != null)
+                        {
 
-                    return true;
-                }
-            }
+                            var argument = accessor.ArgumentList.Arguments.FirstOrDefault();
+                            if (argument != null && argument.Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+                            {
+                                result = new LocalizableStringOccurence()
+                                {
+                                    Text = literal.Token.ValueText,
+                                    Context = this.MetadataProvider.GetContext(node),
+                                    Location = this.MetadataProvider.GetLocation(node)
+                                };
+
+                                return true;
+                            }
+                        }
 
             return false;
         }

--- a/PoExtractor.DotNet.VB/PluralStringExtractor.cs
+++ b/PoExtractor.DotNet.VB/PluralStringExtractor.cs
@@ -15,9 +15,11 @@ namespace PoExtractor.DotNet.VB
     /// </remarks>
     public class PluralStringExtractor : LocalizableStringExtractor<SyntaxNode>
     {
-        public PluralStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider) : base(metadataProvider)
-        {
+        private string[] localizerIdentifiers;
 
+        public PluralStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider, string identifier) : base(metadataProvider)
+        {
+            localizerIdentifiers = LocalizerAccessors.LocalizerIdentifiers.Append(identifier).ToArray();
         }
 
         public override bool TryExtract(SyntaxNode node, out LocalizableStringOccurence result)
@@ -27,7 +29,7 @@ namespace PoExtractor.DotNet.VB
             if (node is InvocationExpressionSyntax invocation &&
                 invocation.Expression is MemberAccessExpressionSyntax accessor &&
                 accessor.Expression is IdentifierNameSyntax identifierName &&
-                LocalizerAccessors.LocalizerIdentifiers.Contains(identifierName.Identifier.Text) &&
+                localizerIdentifiers.Contains(identifierName.Identifier.Text) &&
                 accessor.Name.Identifier.Text == "Plural")
             {
                 var arguments = invocation.ArgumentList.Arguments;

--- a/PoExtractor.DotNet.VB/SingularStringExtractor.cs
+++ b/PoExtractor.DotNet.VB/SingularStringExtractor.cs
@@ -15,9 +15,11 @@ namespace PoExtractor.DotNet.VB
     /// </remarks>
     public class SingularStringExtractor : LocalizableStringExtractor<SyntaxNode>
     {
-        public SingularStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider) : base(metadataProvider)
-        {
+        private string[] localizerIdentifiers;
 
+        public SingularStringExtractor(IMetadataProvider<SyntaxNode> metadataProvider, string identifier) : base(metadataProvider)
+        {
+            localizerIdentifiers = LocalizerAccessors.LocalizerIdentifiers.Append(identifier).ToArray();
         }
 
         public override bool TryExtract(SyntaxNode node, out LocalizableStringOccurence result)
@@ -26,7 +28,7 @@ namespace PoExtractor.DotNet.VB
 
             if (node is InvocationExpressionSyntax accessor &&
                 accessor.Expression is IdentifierNameSyntax identifierName &&
-                LocalizerAccessors.LocalizerIdentifiers.Contains(identifierName.Identifier.Text) &&
+                localizerIdentifiers.Contains(identifierName.Identifier.Text) &&
                 accessor.ArgumentList != null)
             {
                 var argument = accessor.ArgumentList.Arguments.FirstOrDefault();

--- a/PoExtractor.DotNet.VB/VisualBasicProjectProcessor.cs
+++ b/PoExtractor.DotNet.VB/VisualBasicProjectProcessor.cs
@@ -15,6 +15,13 @@ namespace PoExtractor.DotNet.VB
     /// </summary>
     public class VisualBasicProjectProcessor : RazorViewsProcessor
     {
+        private readonly string identifier;
+
+        public VisualBasicProjectProcessor(string identifier)
+        {
+            this.identifier = identifier;
+        }
+
         public override void Process(string path, string basePath, LocalizableStringCollection strings)
         {
             /* VB */
@@ -22,8 +29,8 @@ namespace PoExtractor.DotNet.VB
             var csharpWalker = new ExtractingCodeWalker(
                 new IStringExtractor<SyntaxNode>[]
                 {
-                    new SingularStringExtractor(codeMetadataProvider),
-                    new PluralStringExtractor(codeMetadataProvider),
+                    new SingularStringExtractor(codeMetadataProvider, identifier),
+                    new PluralStringExtractor(codeMetadataProvider, identifier),
                     new ErrorMessageAnnotationStringExtractor(codeMetadataProvider),
                     new DisplayAttributeDescriptionStringExtractor(codeMetadataProvider),
                     new DisplayAttributeNameStringExtractor(codeMetadataProvider),
@@ -55,8 +62,8 @@ namespace PoExtractor.DotNet.VB
         protected override IStringExtractor<SyntaxNode>[] GetStringExtractors(RazorMetadataProvider razorMetadataProvider)
             => new IStringExtractor<SyntaxNode>[]
             {
-                new SingularStringExtractor(razorMetadataProvider),
-                new PluralStringExtractor(razorMetadataProvider),
+                new SingularStringExtractor(razorMetadataProvider, identifier),
+                new PluralStringExtractor(razorMetadataProvider, identifier),
                 new ErrorMessageAnnotationStringExtractor(razorMetadataProvider),
                 new DisplayAttributeDescriptionStringExtractor(razorMetadataProvider),
                 new DisplayAttributeNameStringExtractor(razorMetadataProvider),

--- a/PoExtractor.OrchardCore/Program.cs
+++ b/PoExtractor.OrchardCore/Program.cs
@@ -19,6 +19,7 @@ namespace PoExtractor.OrchardCore {
 
             var basePath = args[0];
             var outputBasePath = args[1];
+            var identifier = args[2];
 
             string[] projectFiles;
             if (Directory.Exists(basePath)) {
@@ -31,8 +32,8 @@ namespace PoExtractor.OrchardCore {
 
             var processors = new List<IProjectProcessor>
             {
-                new CSharpProjectProcessor(),
-                new VisualBasicProjectProcessor()
+                new CSharpProjectProcessor(identifier),
+                new VisualBasicProjectProcessor(identifier)
             };
 
             processors.Add(new LiquidProjectProcessor());

--- a/PoExtractor/Program.cs
+++ b/PoExtractor/Program.cs
@@ -17,6 +17,7 @@ namespace PoExtractor {
 
             var basePath = args[0];
             var outputBasePath = args[1];
+            var identifier = args[2];
 
             string[] projectFiles;
             if (Directory.Exists(basePath)) {
@@ -28,8 +29,8 @@ namespace PoExtractor {
             }
 
             var processors = new IProjectProcessor[] {
-                new CSharpProjectProcessor(),
-                new VisualBasicProjectProcessor()
+                new CSharpProjectProcessor(identifier),
+                new VisualBasicProjectProcessor(identifier)
             };
 
             foreach (var projectFilePath in projectFiles) {


### PR DESCRIPTION
Adds the possibility to use a localization-identifier via CLI command for localization instead of using the convention.