### PR TITLE
Escape \r\n

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor/PoWriter.cs
+++ b/src/OrchardCoreContrib.PoExtractor/PoWriter.cs
@@ -104,6 +104,8 @@ namespace OrchardCoreContrib.PoExtractor
             var sb = new StringBuilder(text);
             sb.Replace("\\", "\\\\"); // \ -> \\
             sb.Replace("\"", "\\\""); // " -> \"
+            sb.Replace("\r", "\\r");
+            sb.Replace("\n", "\\n");
 
             return sb.ToString();
         }

--- a/test/OrchardCoreContrib.PoExtractor.Tests/PoWriterTests.cs
+++ b/test/OrchardCoreContrib.PoExtractor.Tests/PoWriterTests.cs
@@ -28,6 +28,27 @@ namespace OrchardCoreContrib.PoExtractor.Tests
         }
 
         [Fact]
+        public void WriteRecord_Escapes()
+        {
+            // Arrange
+            var localizableString = new LocalizableString
+            {
+                Text = "Computer \r\n"
+            };
+
+            // Act
+            using (var writer = new PoWriter(_stream))
+            {
+                writer.WriteRecord(localizableString);
+            }
+
+            // Assert
+            var result = ReadPoStream();
+            Assert.Equal($"msgid \"Computer \\r\\n\"", result[0]);
+            Assert.Equal($"msgstr \"\"", result[1]);
+        }
+
+        [Fact]
         public void WriteRecord_WritesPluralLocalizableString()
         {
             // Arrange


### PR DESCRIPTION
Tested with: 

```
S["Webhook {0} with subscription of {1} deletion failed. \r\n{3}"
```

Result:

```
msgid "Webhook {0} with subscription of {1} deletion failed. \r\n{3}"
msgstr ""
```

Added unit test for \r and \n

Fixes #76
