### PR TITLE
Fix #88 - wrong `msgctxt` for *.razor files

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor.Razor/MetadataProviders/RazorMetadataProvider.cs
+++ b/src/OrchardCoreContrib.PoExtractor.Razor/MetadataProviders/RazorMetadataProvider.cs
@@ -12,7 +12,8 @@ namespace OrchardCoreContrib.PoExtractor.Razor.MetadataProviders
     /// </summary>
     public class RazorMetadataProvider : IMetadataProvider<SyntaxNode>
     {
-        private static readonly string _razorExtension = ".cshtml";
+        private static readonly string _razorPageExtension = ".cshtml";
+        private static readonly string _razorComponentExtension = ".razor";
 
         private string[] _sourceCache;
         private string _sourceCachePath;
@@ -37,8 +38,16 @@ namespace OrchardCoreContrib.PoExtractor.Razor.MetadataProviders
             }
 
             var path = node.SyntaxTree.FilePath.TrimStart(_basePath);
+            path = RemoveRazorFileExtension(path);
+            return path.Replace(Path.DirectorySeparatorChar, '.');
+        }
 
-            return path.Replace(Path.DirectorySeparatorChar, '.').Replace(_razorExtension, string.Empty);
+        private static string RemoveRazorFileExtension(
+            string path)
+        {
+            return path
+                .Replace(_razorPageExtension, string.Empty)
+                .Replace(_razorComponentExtension, string.Empty);
         }
 
         /// <inheritdoc/>

--- a/src/OrchardCoreContrib.PoExtractor.Razor/MetadataProviders/RazorMetadataProvider.cs
+++ b/src/OrchardCoreContrib.PoExtractor.Razor/MetadataProviders/RazorMetadataProvider.cs
@@ -39,11 +39,11 @@ namespace OrchardCoreContrib.PoExtractor.Razor.MetadataProviders
 
             var path = node.SyntaxTree.FilePath.TrimStart(_basePath);
             path = RemoveRazorFileExtension(path);
+
             return path.Replace(Path.DirectorySeparatorChar, '.');
         }
 
-        private static string RemoveRazorFileExtension(
-            string path)
+        private static string RemoveRazorFileExtension(string path)
         {
             return path
                 .Replace(_razorPageExtension, string.Empty)


### PR DESCRIPTION
## Change

Fixes #88 by removing the file ending of razor templates, no matter what the file ending is (*.cshtml, *.razor).

I think this is better than replacing `.cshtml` and `.razor` explicitly, because the build system support other file endings - or add new support for them - and the file ending should *never* be part of the `msgctxt` anyway.

## Tests performed
I manually ran the po extractor and verified that it now generates correct `msgctxt` for us and nothing else changes:
![image](https://github.com/OrchardCoreContrib/OrchardCoreContrib.PoExtractor/assets/2090172/5624f4ee-56fe-4988-a383-23834202e81f)

Also, all the automated tests still pass:
![Uploading image.png…]()

## Side-Note -- Convention Logic
There is further room for improvement. The current logic builds the `msgctxt` basically *by convention* based on the file path.
The convention is, that the class name is the same as the file name, and the directory path is the same as the namespace (of course, with directory separator instead of a `.`).

If this convention is not adhered to, the `msgctxt` will be wrong.

It would be more stable if the actual class and namespace name would be taken from the source. Not sure how easy this would be to achieve.