### PR TITLE
Fix display of number of localizable strings per project

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor/Program.cs
+++ b/src/OrchardCoreContrib.PoExtractor/Program.cs
@@ -105,10 +105,10 @@ public class Program
 
                     using var potFile = new PoWriter(potPath);
                     potFile.WriteRecord(localizableStrings.Values);
-                    localizableStrings.Clear();
                 }
 
                 Console.WriteLine($"{Path.GetFileName(projectPath)}: Found {localizableStrings.Values.Count()} strings.");
+                localizableStrings.Clear();
             }
         }
 


### PR DESCRIPTION
When we extract a POT file per project, the number of localizable strings is always 0 because the collection is cleared before being written to the console.