### PR TITLE
Fix missing negation when exporting not in Single File mode

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor/Program.cs
+++ b/src/OrchardCoreContrib.PoExtractor/Program.cs
@@ -102,7 +102,7 @@ public class Program
                     projectProcessor.Process(projectPath, projectBasePath, localizableStrings);
                 }
 
-                if (isSingleFileOutput)
+                if (!isSingleFileOutput)
                 {
                     if (localizableStrings.Values.Any())
                     {


### PR DESCRIPTION
Without this fix, the tool in `main` generates no output by default and outputs both single file and multi file POT files when single file mode is enabled.