### PR TITLE
Respect default localizers if none are set

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor/Program.cs
+++ b/src/OrchardCoreContrib.PoExtractor/Program.cs
@@ -60,7 +60,10 @@ public class Program
                 IgnoredProject.Add(ignoredProject);
             }
 
-            LocalizerAccessors.LocalizerIdentifiers = [.. localizers.Values];
+            if (localizers.Values.Count > 0)
+            {
+                LocalizerAccessors.LocalizerIdentifiers = [.. localizers.Values];
+            }
 
             var projectFiles = new List<string>();
             var projectProcessors = new List<IProjectProcessor>();


### PR DESCRIPTION
If the command is invoked without `--localizer T`, the default localizers (`T`, `S`, `H`) are not set. This PR fixes that.