### PR TITLE
Msgctxt without project name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C#: OrchardCoreContrib.PoExtractor Debug",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/OrchardCoreContrib.PoExtractor/bin/Debug/net8.0/OrchardCoreContrib.PoExtractor.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/OrchardCoreContrib.PoExtractor.Razor/MetadataProviders/RazorMetadataProvider.cs
+++ b/src/OrchardCoreContrib.PoExtractor.Razor/MetadataProviders/RazorMetadataProvider.cs
@@ -35,6 +35,7 @@ public class RazorMetadataProvider : IMetadataProvider<SyntaxNode>
         ArgumentNullException.ThrowIfNull(node);
 
         var path = node.SyntaxTree.FilePath.TrimStart(_basePath);
+        path = RemoveProjectNameFromPath(path);
         path = RemoveRazorFileExtension(path);
 
         return path.Replace(Path.DirectorySeparatorChar, '.');
@@ -107,5 +108,26 @@ public class RazorMetadataProvider : IMetadataProvider<SyntaxNode>
         }
 
         return null;
+    }
+
+    private static string RemoveProjectNameFromPath(string path)
+    {
+        // Remove leading directory separator if present
+        if (path.StartsWith(Path.DirectorySeparatorChar))
+        {
+            path = path.Substring(1);
+        }
+
+        // Find the first directory separator to locate the project name
+        var firstSeparatorIndex = path.IndexOf(Path.DirectorySeparatorChar);
+        
+        // If there's no separator, just return the path as is
+        if (firstSeparatorIndex == -1)
+        {
+            return path;
+        }
+
+        // Remove the project name (everything before the first separator)
+        return path.Substring(firstSeparatorIndex + 1);
     }
 }

--- a/src/OrchardCoreContrib.PoExtractor/Program.cs
+++ b/src/OrchardCoreContrib.PoExtractor/Program.cs
@@ -110,7 +110,6 @@ public class Program
             {
                 var projectPath = Path.GetDirectoryName(projectFile);
                 var projectBasePath = Path.GetDirectoryName(projectPath) + Path.DirectorySeparatorChar;
-                var projectRelativePath = projectPath[projectBasePath.Length..];
                 var rootedProject = projectPath == inputPath.Value
                     ? projectPath 
                     : projectPath[(projectPath.IndexOf(inputPath.Value, StringComparison.Ordinal) + inputPath.Value.Length + 1)..];

--- a/test/OrchardCoreContrib.PoExtractor.Razor.Tests/OrchardCoreContrib.PoExtractor.Razor.Tests.csproj
+++ b/test/OrchardCoreContrib.PoExtractor.Razor.Tests/OrchardCoreContrib.PoExtractor.Razor.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/OrchardCoreContrib.PoExtractor.Razor/OrchardCoreContrib.PoExtractor.Razor.csproj" />
+  <PackageReference Include="xunit" />
+  <PackageReference Include="xunit.runner.visualstudio" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  <None Include="Sample/**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/test/OrchardCoreContrib.PoExtractor.Razor.Tests/RazorMetadataProviderIntegrationTests.cs
+++ b/test/OrchardCoreContrib.PoExtractor.Razor.Tests/RazorMetadataProviderIntegrationTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using OrchardCoreContrib.PoExtractor.Razor.MetadataProviders;
+using System.IO;
+using Xunit;
+
+namespace OrchardCoreContrib.PoExtractor.Razor.Tests
+{
+    public class RazorMetadataProviderIntegrationTests
+    {
+        [Fact]
+        public void GetContext_RemovesProjectNameFromPath()
+        {
+            // Arrange
+            // The test runs from the output directory, so use relative paths
+            var outputDir = Directory.GetCurrentDirectory();
+            var basePath = Path.Combine(outputDir, "Sample");
+            var filePath = Path.Combine(basePath, "MyProject", "Views", "Home", "Index.cshtml");
+            var code = File.ReadAllText(filePath);
+
+            // Create a dummy syntax tree for the file
+            var syntaxTree = CSharpSyntaxTree.ParseText(code, path: filePath);
+            var root = syntaxTree.GetRoot();
+
+            var provider = new RazorMetadataProvider(basePath);
+
+            // Act
+            var context = provider.GetContext(root);
+
+            // Assert
+            Assert.Equal("Views.Home.Index", context);
+        }
+    }
+}

--- a/test/OrchardCoreContrib.PoExtractor.Razor.Tests/RazorMetadataProviderTests.cs
+++ b/test/OrchardCoreContrib.PoExtractor.Razor.Tests/RazorMetadataProviderTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace OrchardCoreContrib.PoExtractor.Razor.Tests
+{
+    public class RazorMetadataProviderTests
+    {
+        [Theory]
+        [InlineData("/MyProject/Views/Home/Index.cshtml", "Views/Home/Index.cshtml")]
+        [InlineData("\\MyProject\\Views\\Home\\Index.cshtml", "Views/Home/Index.cshtml")]
+        [InlineData("MyProject/Index.cshtml", "Index.cshtml")]
+        [InlineData("Index.cshtml", "Index.cshtml")]
+        public void RemoveProjectNameFromPath_RemovesProjectName(string input, string expected)
+        {
+            // Use reflection to access the private static method
+            var type = typeof(OrchardCoreContrib.PoExtractor.Razor.MetadataProviders.RazorMetadataProvider);
+            var method = type.GetMethod("RemoveProjectNameFromPath", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            // Normalize input for current OS
+            var normalizedInput = input.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+            var normalizedExpected = expected.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+
+            var result = (string)method.Invoke(null, new object[] { normalizedInput });
+            Assert.Equal(normalizedExpected, result);
+        }
+    }
+}

--- a/test/OrchardCoreContrib.PoExtractor.Razor.Tests/Sample/MyProject/Views/Home/Index.cshtml
+++ b/test/OrchardCoreContrib.PoExtractor.Razor.Tests/Sample/MyProject/Views/Home/Index.cshtml
@@ -1,0 +1,7 @@
+@* Sample Razor View *@
+@{
+    ViewData["Title"] = "Home Page";
+}
+
+<h1>Welcome</h1>
+<p>This is a sample view.</p>

--- a/test/OrchardCoreContrib.PoExtractor.Razor.Tests/Sample/Views/Home/Index.cshtml
+++ b/test/OrchardCoreContrib.PoExtractor.Razor.Tests/Sample/Views/Home/Index.cshtml
@@ -1,0 +1,7 @@
+@* Sample Razor View *@
+@{
+    ViewData["Title"] = "Home Page";
+}
+
+<h1>Welcome</h1>
+<p>This is a sample view.</p>


### PR DESCRIPTION
This change adds two unit tests that remove the project name from the and actually removes the project name from the generated context only for Razor metadata.

I created a sample project that this can be tested on: https://github.com/skyflyer/DotnetPoLocalizationDemo

The sample projects includes localization in `.cshtml` as well as localization in `.cs` (HomeController), which must preserve the project name (as it is part of the fully qualified class name).