### PR TITLE
Fix default template engine not loading Razor/Liquid processors

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor/TemplateEngine.cs
+++ b/src/OrchardCoreContrib.PoExtractor/TemplateEngine.cs
@@ -6,5 +6,5 @@ public class TemplateEngine
 
     public static readonly string Razor = "Razor";
 
-    public static readonly string Both = string.Empty;
+    public static readonly string Both = null;
 }


### PR DESCRIPTION
## Fix Razor/Liquid template extraction not running by default

After the migration to `CommandLineUtils`, `template.Value()` returns `null` when `-t` isn't specified, but `TemplateEngine.Both` was `string.Empty`. Since `null != ""`, the Razor and Liquid processors never got added unless `-t` was explicitly passed.

Fixed `TemplateEngine.Both` to be `null` instead of `string.Empty`.

**Reproduce:**

Create a Razor file with localizable strings, e.g.:
```razor
@inject IStringLocalizer<Home> S
<p>@S["Welcome to MudBlazor"]</p>
<p>@S["This is a test of string extraction."]</p>
<p>@S.Plural(5,"You have {0} notification.", "You have {0} notifications.", 6)</p>
<p>@S["Hello {0}, you have {1} notifications.", "User", 5]</p>
```

```
# before fix
dotnet run --project src/OrchardCoreContrib.PoExtractor -- /path/to/project /tmp/output
# shows: Found 0 strings.

# after fix
dotnet run --project src/OrchardCoreContrib.PoExtractor -- /path/to/project /tmp/output
# shows: Found 4 strings.
```

Confirmed working on v1.2.0 (d85eda7) as a reference.