### PR TITLE
Add liquid processor configuration file option to support custom inline and block tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dotnet tool install --global OrchardCoreContrib.PoExtractor
 ## Usage
 
 ```powershell
-extractpo <INTPUT_PATH> <OUTPUT_PATH> [-l|--language {"C#"|"VB"}] [-t|--template {"razor"|"liquid"}]
+extractpo <INTPUT_PATH> <OUTPUT_PATH> [-l|--language {"C#"|"VB"}] [-t|--template {"razor"|"liquid"}] [--liquid-processor-configuration {path to JSON file}]
 ```
 
 ### Description
@@ -59,6 +59,19 @@ When executing the plugins, all _OrchardCoreContrib.PoExtractor_ assemblies are 
 > using OrchardCore.Commerce.Constants;
 > Console.WriteLine("Imported resource name: {0}", ResourceNames.ShoppingCart);
 > ```
+
+- **`--liquid-processor-configuration {path to JSON file}`**
+
+Specifies the path to a JSON file with `LiquidProcessorConfiguration`, containing `InlineTags` and `BlockTags` arrays used to register custom Liquid tags during parsing.
+
+Example:
+
+```json
+{
+  "InlineTags": ["resources", "link", "script", "style"],
+  "BlockTags": ["edit_custom_settings", "scriptblock", "styleblock", "EditCustomSettings"]
+}
+```
 
 ## Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dotnet tool install --global OrchardCoreContrib.PoExtractor
 ## Usage
 
 ```powershell
-extractpo <INTPUT_PATH> <OUTPUT_PATH> [-l|--language {"C#"|"VB"}] [-t|--template {"razor"|"liquid"}] [--liquid-processor-configuration {path to JSON file}]
+extractpo <INPUT_PATH> <OUTPUT_PATH> [-l|--language {"C#"|"VB"}] [-t|--template {"razor"|"liquid"}] [--liquid-processor-configuration {path to JSON file}]
 ```
 
 ### Description

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Example:
 
 ```json
 {
-  "InlineTags": ["resources", "link", "script", "style"],
-  "BlockTags": ["edit_custom_settings", "scriptblock", "styleblock", "EditCustomSettings"]
+  "InlineTags": ["resources", "link", "script", "style", "yourcustomtag"],
+  "BlockTags": ["scriptblock", "styleblock"]
 }
 ```
 

--- a/src/OrchardCoreContrib.PoExtractor.Liquid/LiquidProcessorConfiguration.cs
+++ b/src/OrchardCoreContrib.PoExtractor.Liquid/LiquidProcessorConfiguration.cs
@@ -1,0 +1,8 @@
+namespace OrchardCoreContrib.PoExtractor.Liquid;
+
+public class LiquidProcessorConfiguration
+{
+    public IReadOnlyList<string> InlineTags { get; set; } = [];
+
+    public IReadOnlyList<string> BlockTags { get; set; } = [];
+}

--- a/src/OrchardCoreContrib.PoExtractor.Liquid/LiquidProjectProcessor.cs
+++ b/src/OrchardCoreContrib.PoExtractor.Liquid/LiquidProjectProcessor.cs
@@ -18,13 +18,39 @@ public class LiquidProjectProcessor : IProjectProcessor
     /// <summary>
     /// Initializes a new instance of the <see cref="LiquidProjectProcessor"/>
     /// </summary>
-    public LiquidProjectProcessor()
+    public LiquidProjectProcessor(LiquidProcessorConfiguration configuration = null)
     {
-        var liquidViewOptions = Options.Create(new LiquidViewOptions());
+        configuration ??= new LiquidProcessorConfiguration();
+
+        var liquidViewOptions = new LiquidViewOptions();
+        liquidViewOptions.LiquidViewParserConfiguration.Add(parser =>
+        {
+            foreach (var tag in NormalizeTags(configuration.InlineTags))
+            {
+                parser.RegisterParserTag(
+                    tag,
+                    parser.ArgumentsListParser,
+                    static (_, _, _, _) => System.Threading.Tasks.ValueTask.FromResult(Fluid.Ast.Completion.Normal));
+            }
+
+            foreach (var tag in NormalizeTags(configuration.BlockTags))
+            {
+                parser.RegisterParserBlock(
+                    tag,
+                    parser.ArgumentsListParser,
+                    static (_, _, _, _, _) => System.Threading.Tasks.ValueTask.FromResult(Fluid.Ast.Completion.Normal));
+            }
+        });
+
         var fileParserOptions = Options.Create(new FluidParserOptions());
 
-        _parser = new LiquidViewParser(liquidViewOptions, fileParserOptions);
+        _parser = new LiquidViewParser(Options.Create(liquidViewOptions), fileParserOptions);
     }
+
+    private static IEnumerable<string> NormalizeTags(IReadOnlyList<string> tags) => tags?
+        .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+        .Distinct(StringComparer.Ordinal)
+        ?? [];
 
     /// <inheritdoc/>
     public void Process(string path, string basePath, LocalizableStringCollection localizableStrings)
@@ -43,6 +69,10 @@ public class LiquidProjectProcessor : IProjectProcessor
             if (_parser.TryParse(reader.ReadToEnd(), out var template, out var errors))
             {
                 ProcessTemplate(template, liquidVisitor, file);
+            }
+            else
+            {
+                Console.WriteLine($"Error: {errors}, file: {file}");
             }
         }
     }

--- a/src/OrchardCoreContrib.PoExtractor.Liquid/LiquidProjectProcessor.cs
+++ b/src/OrchardCoreContrib.PoExtractor.Liquid/LiquidProjectProcessor.cs
@@ -27,18 +27,12 @@ public class LiquidProjectProcessor : IProjectProcessor
         {
             foreach (var tag in NormalizeTags(configuration.InlineTags))
             {
-                parser.RegisterParserTag(
-                    tag,
-                    parser.ArgumentsListParser,
-                    static (_, _, _, _) => System.Threading.Tasks.ValueTask.FromResult(Fluid.Ast.Completion.Normal));
+                parser.RegisterParserTag(tag, parser.ArgumentsListParser, static (_, _, _, _) => ValueTask.FromResult(Fluid.Ast.Completion.Normal));
             }
 
             foreach (var tag in NormalizeTags(configuration.BlockTags))
             {
-                parser.RegisterParserBlock(
-                    tag,
-                    parser.ArgumentsListParser,
-                    static (_, _, _, _, _) => System.Threading.Tasks.ValueTask.FromResult(Fluid.Ast.Completion.Normal));
+                parser.RegisterParserBlock(tag, parser.ArgumentsListParser, static (_, _, _, _, _) => ValueTask.FromResult(Fluid.Ast.Completion.Normal));
             }
         });
 

--- a/src/OrchardCoreContrib.PoExtractor/Program.cs
+++ b/src/OrchardCoreContrib.PoExtractor/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using McMaster.Extensions.CommandLineUtils;
 using OrchardCore.Modules;
 using OrchardCoreContrib.PoExtractor.DotNet;
@@ -37,6 +38,33 @@ public class Program
         var ignoredProjects = app.Option("-i|--ignore <IGNORED_PROJECTS>", "Ignores extracting PO files from a given project(s).", CommandOptionType.MultipleValue);
         var localizers = app.Option("--localizer <LOCALIZERS>", "Specifies the name of the localizer(s) that will be used during the extraction process.", CommandOptionType.MultipleValue);
         var single = app.Option("-s|--single <FILE_NAME>", "Specifies the single output file.", CommandOptionType.SingleValue);
+        var liquidProcessorConfigurationPath = app.Option(
+            "--liquid-processor-configuration <FILE_NAME>",
+            "Specifies a path to a JSON file with LiquidProcessorConfiguration (InlineTags and BlockTags).",
+            CommandOptionType.SingleValue,
+            option => option.OnValidate(_ =>
+            {
+                if (!option.HasValue())
+                {
+                    return ValidationResult.Success;
+                }
+
+                if (!File.Exists(option.Value()))
+                {
+                    return new ValidationResult("Liquid processor configuration must be an existing local file.");
+                }
+
+                try
+                {
+                    LoadLiquidProcessorConfiguration(option.Value());
+
+                    return ValidationResult.Success;
+                }
+                catch (JsonException ex)
+                {
+                    return new ValidationResult($"Liquid processor configuration must be valid JSON: {ex.Message}");
+                }
+            }));
         var plugins = app.Option(
             "-p|--plugin <FILE_NAME_OR_HTTPS_URL>",
             "A path or web URL with HTTPS scheme to a C# script (.csx) file which can define further " +
@@ -69,6 +97,9 @@ public class Program
 
             var projectFiles = new List<string>();
             var projectProcessors = new List<IProjectProcessor>();
+            var liquidProcessorConfiguration = liquidProcessorConfigurationPath.HasValue()
+                ? LoadLiquidProcessorConfiguration(liquidProcessorConfigurationPath.Value())
+                : new LiquidProcessorConfiguration();
 
             if (language.Value() == Language.CSharp)
             {
@@ -90,7 +121,7 @@ public class Program
             if (template.Value() == TemplateEngine.Both)
             {
                 projectProcessors.Add(new RazorProjectProcessor());
-                projectProcessors.Add(new LiquidProjectProcessor());
+                projectProcessors.Add(new LiquidProjectProcessor(liquidProcessorConfiguration));
             }
             else if (template.Value() == TemplateEngine.Razor)
             {
@@ -98,7 +129,7 @@ public class Program
             }
             else if (template.Value() == TemplateEngine.Liquid)
             {
-                projectProcessors.Add(new LiquidProjectProcessor());
+                projectProcessors.Add(new LiquidProjectProcessor(liquidProcessorConfiguration));
             }
 
             if (plugins.Values.Count > 0)
@@ -161,4 +192,10 @@ public class Program
 
         app.Execute(args);
     }
+
+    private static LiquidProcessorConfiguration LoadLiquidProcessorConfiguration(string path)
+        => JsonSerializer.Deserialize<LiquidProcessorConfiguration>(
+               File.ReadAllText(path),
+               new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+           ?? new LiquidProcessorConfiguration();
 }

--- a/src/OrchardCoreContrib.PoExtractor/Program.cs
+++ b/src/OrchardCoreContrib.PoExtractor/Program.cs
@@ -64,6 +64,10 @@ public class Program
                 {
                     return new ValidationResult($"Liquid processor configuration must be valid JSON: {ex.Message}");
                 }
+                catch (Exception ex)
+                {
+                    return new ValidationResult($"Liquid processor configuration could not be read: {ex.Message}");
+                }
             }));
         var plugins = app.Option(
             "-p|--plugin <FILE_NAME_OR_HTTPS_URL>",
@@ -193,9 +197,9 @@ public class Program
         app.Execute(args);
     }
 
-    private static LiquidProcessorConfiguration LoadLiquidProcessorConfiguration(string path)
-        => JsonSerializer.Deserialize<LiquidProcessorConfiguration>(
-               File.ReadAllText(path),
-               new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-           ?? new LiquidProcessorConfiguration();
+    private static LiquidProcessorConfiguration LoadLiquidProcessorConfiguration(string path) => 
+        string.IsNullOrWhiteSpace(path) || !File.Exists(path)
+            ? new LiquidProcessorConfiguration()
+            : JsonSerializer.Deserialize<LiquidProcessorConfiguration>(File.ReadAllText(path), new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+               ?? new LiquidProcessorConfiguration();
 }

--- a/test/OrchardCoreContrib.PoExtractor.Tests/ProgramTests.cs
+++ b/test/OrchardCoreContrib.PoExtractor.Tests/ProgramTests.cs
@@ -60,4 +60,68 @@ public class ProgramTests
             }
         }
     }
+
+    [Fact]
+    public void Main_LiquidProcessorConfigurationOption_LoadsLiquidTagsFromJsonFile()
+    {
+        // Arrange
+        var root = Path.Combine(Path.GetTempPath(), "PoExtractorTests", Guid.NewGuid().ToString("N"));
+        var input = Path.Combine(root, "input");
+        var output = Path.Combine(root, "output");
+        var project = Path.Combine(input, "TestModule");
+        var configurationPath = Path.Combine(root, "liquid-config.json");
+
+        Directory.CreateDirectory(project);
+        Directory.CreateDirectory(output);
+
+        File.WriteAllText(Path.Combine(project, "TestModule.csproj"), """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+""");
+
+        File.WriteAllText(Path.Combine(project, "index.liquid"), """
+{% scriptblock at:"FootScript" %}
+{{ "Hello from Liquid configured tag" | t }}
+{% endscriptblock %}
+""");
+
+        File.WriteAllText(configurationPath, """
+{
+  "InlineTags": [],
+  "BlockTags": ["scriptblock"]
+}
+""");
+
+        var potFileName = "liquid-config.pot";
+
+        try
+        {
+            // Act
+            Program.Main(
+            [
+                input,
+                output,
+                "--template", "Liquid",
+                "--liquid-processor-configuration", configurationPath,
+                "--single", potFileName
+            ]);
+
+            // Assert
+            var potPath = Path.Combine(output, potFileName);
+            Assert.True(File.Exists(potPath));
+
+            var pot = File.ReadAllText(potPath);
+            Assert.Contains("Hello from Liquid configured tag", pot);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Issue:** https://github.com/OrchardCoreContrib/OrchardCoreContrib.PoExtractor/issues/124

- **`--liquid-processor-configuration {path to JSON file}`**

Specifies the path to a JSON file with `LiquidProcessorConfiguration`, containing `InlineTags` and `BlockTags` arrays used to register custom Liquid tags during parsing.

Example:

```json
{
  "InlineTags": ["resources", "link", "script", "style"],
  "BlockTags": ["scriptblock", "styleblock"]
}
```