### PR TITLE
Support concatenated localizer strings

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor.DotNet.CS/SingularStringExtractor.cs
+++ b/src/OrchardCoreContrib.PoExtractor.DotNet.CS/SingularStringExtractor.cs
@@ -33,13 +33,34 @@ public class SingularStringExtractor(IMetadataProvider<SyntaxNode> metadataProvi
         {
 
             var argument = accessor.ArgumentList.Arguments.FirstOrDefault();
-            if (argument != null && argument.Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+            if (argument != null && TryGetString(argument.Expression, out var value))
             {
-                result = CreateLocalizedString(literal.Token.ValueText, null, node);
+                result = CreateLocalizedString(value, null, node);
                 return true;
             }
         }
 
+        return false;
+    }
+
+    private static bool TryGetString(ExpressionSyntax expression, out string value)
+    {
+        if (expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            value = literal.Token.ValueText;
+            return true;
+        }
+
+        if (expression is BinaryExpressionSyntax binary &&
+            binary.IsKind(SyntaxKind.AddExpression) &&
+            TryGetString(binary.Left, out var left) &&
+            TryGetString(binary.Right, out var right))
+        {
+            value = left + right;
+            return true;
+        }
+
+        value = null;
         return false;
     }
 }

--- a/test/OrchardCoreContrib.PoExtractor.DotNet.CS.Tests/SingularStringExtractorTests.cs
+++ b/test/OrchardCoreContrib.PoExtractor.DotNet.CS.Tests/SingularStringExtractorTests.cs
@@ -14,7 +14,7 @@ public class SingularStringExtractorTests
         var extractor = new SingularStringExtractor(metadataProvider);
 
         var syntaxTree = CSharpSyntaxTree.ParseText($"S[\"{text}\"];", path: "DummyPath");
-        
+
         var node = syntaxTree
             .GetRoot()
             .DescendantNodes()
@@ -26,5 +26,35 @@ public class SingularStringExtractorTests
         // Assert
         Assert.True(extracted);
         Assert.Equal(text, result.Text);
+    }
+
+    [Theory]
+    [InlineData("""S["my " + "text"];""", "my text")]
+    [InlineData("""S["a " + "long " + "text"];""", "a long text")]
+    [InlineData(
+        """
+        S["This is a long piece of text " +
+          "continued on another line."];
+        """,
+        "This is a long piece of text continued on another line.")]
+    public void ExtractConcatenatedString(string source, string expected)
+    {
+        // Arrange
+        var metadataProvider = new CSharpMetadataProvider("DummyBasePath");
+        var extractor = new SingularStringExtractor(metadataProvider);
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "DummyPath");
+
+        var node = syntaxTree
+            .GetRoot()
+            .DescendantNodes()
+            .ElementAt(2);
+
+        // Act
+        var extracted = extractor.TryExtract(node, out var result);
+
+        // Assert
+        Assert.True(extracted);
+        Assert.Equal(expected, result.Text);
     }
 }


### PR DESCRIPTION
Support concatenated localizer strings (`S["my " + "text"]`), allowing breaking of long strings into multiple lines.